### PR TITLE
feat: Initialize PNPM workspace with basic structure [Task #1.1]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dev-debug.log
+
+# Dependency directories
+node_modules/
+
+# Environment variables
+.env
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# OS specific
+.DS_Store
+
+# Task files
+tasks.json
+tasks/
+scripts/
+
+# Cursor
+.cursor/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "turborepo-monorepo-template",
+  "version": "0.1.0",
+  "private": true,
+  "description": "A standardized, customizable monorepo template using Turborepo, PNPM, and modern web technologies",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "monorepo",
+    "turborepo",
+    "pnpm",
+    "react",
+    "laravel",
+    "expo"
+  ],
+  "author": "",
+  "license": "MIT",
+  "packageManager": "pnpm@10.9.0",
+  "engines": {
+    "node": ">=16.0.0",
+    "pnpm": ">=7.0.0"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
This pull request sets up the foundational configuration for a new monorepo project using Turborepo and PNPM. The changes include adding a `package.json` file with key metadata and dependencies and defining the workspace structure in a `pnpm-workspace.yaml` file.

### Monorepo setup:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1-R24): Added a new `package.json` file with metadata for the monorepo, including the name, version, description, keywords, and engine requirements. It specifies PNPM as the package manager and includes a placeholder test script.

* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cR1-R3): Defined the workspace structure for PNPM, specifying that the workspace includes packages located in the `apps/*` and `packages/*` directories.